### PR TITLE
Fix email address used in running ModularMain

### DIFF
--- a/zippy/zippy.py
+++ b/zippy/zippy.py
@@ -178,9 +178,9 @@ class ModularMain(WorkflowRunner):
         if mode == 'local':
             if not hasattr(self.params, 'max_cores') or not hasattr(self.params, 'max_memory'):
                 raise IOError('In local mode, must specify max_cores and max_memory for the entire system.')
-            retval = self.run(mode=mode, dataDirRoot=self.params.scratch_path, retryMax=0, mailTo=input_params.email, nCores=wflow.params.max_cores, memMb=wflow.params.max_memory)
+            retval = self.run(mode=mode, dataDirRoot=self.params.scratch_path, retryMax=0, mailTo=mail_to, nCores=wflow.params.max_cores, memMb=wflow.params.max_memory)
         else:
-            retval = self.run(mode=mode, dataDirRoot=self.params.scratch_path, retryMax=0, mailTo=input_params.email)
+            retval = self.run(mode=mode, dataDirRoot=self.params.scratch_path, retryMax=0, mailTo=mail_to)
         return retval
 
 


### PR DESCRIPTION
`input_params` is not a global variable, so that call doesn't work. Replace instead with the mail_to argument in function signature.