### PR TITLE
Feature/refine bwa zippy module

### DIFF
--- a/zippy/bwa.py
+++ b/zippy/bwa.py
@@ -37,7 +37,7 @@ class BWAWorkflow(WorkflowRunner):
         # Figure out the number of cores we can use for alignment and for bam compression
         total_threads = self.cores * 2  # At least 2
         addtl_compression_threads = max(int(0.1 * total_threads), 1) # At a minimum, allocate one extra thread for bam compression
-        bwa_threads = total_threads - addtl_compression_threads  # Because we have at least 2 threads, this is at least 1
+        bwa_threads = total_threads  # Because we have at least 2 threads, this is at least 1
         assert bwa_threads >= 1
         cmd = "%s mem" % self.bwa_exec \
               + " -t %i" % (bwa_threads) \

--- a/zippy/bwa.py
+++ b/zippy/bwa.py
@@ -37,7 +37,7 @@ class BWAWorkflow(WorkflowRunner):
         # Figure out the number of cores we can use for alignment and for bam compression
         total_threads = self.cores * 2  # At least 2
         addtl_compression_threads = max(int(0.1 * total_threads), 1) # At a minimum, allocate one extra thread for bam compression
-        bwa_threads = total_threads  # Because we have at least 2 threads, this is at least 1
+        bwa_threads = total_threads  # Since BWA's output is thread-dependent, we don't decrement here in order to avoid surprises
         assert bwa_threads >= 1
         cmd = "%s mem" % self.bwa_exec \
               + " -t %i" % (bwa_threads) \

--- a/zippy/bwa.py
+++ b/zippy/bwa.py
@@ -60,8 +60,7 @@ class BWAWorkflow(WorkflowRunner):
               + " -O bam" \
               + " -o " + out_sorted_bam \
               + " -T " + out_temp \
-              + " -@ %i" % sort_threads \
-              + " -m {thread_mem_mb}M".format(thread_mem_mb=mem_per_thread)  # Specify in megabytes
+              + " -@ %i" % sort_threads
         self.addTask(label="sort_bam", command=cmd, nCores=self.cores, memMb=self.mem, dependencies="bwamem")
 
         # Clean up the unsorted BAM

--- a/zippy/bwa.py
+++ b/zippy/bwa.py
@@ -54,7 +54,7 @@ class BWAWorkflow(WorkflowRunner):
         out_temp = os.path.join(self.output_dir, "tmp")
         # Calculate resources for sort
         sort_threads = self.cores * 2
-        mem_per_thread = int(math.floor(float(self.mem) / sort_threads * 0.9))  # Per thread, underallocate to allow some overhead
+        mem_per_thread = int(math.floor(float(self.mem) / sort_threads * 0.75))  # Per thread, underallocate to allow some overhead
         cmd = self.samtools_exec \
               + " sort %s" % out_bam \
               + " -O bam" \

--- a/zippy/modular_runner.py
+++ b/zippy/modular_runner.py
@@ -345,7 +345,7 @@ class BWARunner(ModularRunner):
         return {'bam': os.path.join(self.params.self.output_dir, sample.name, sample.name+".raw.bam")}
 
     def define_optionals(self):
-        return {'args': ''}
+        return {'args': '', 'genome_filename': 'genome.fa'}
 
     def workflow(self, workflowRunner):
             self.task = defaultdict(list)
@@ -365,12 +365,12 @@ class BWARunner(ModularRunner):
                     #put R1, then R2 in a list
                     fastq_files = [x for x in itertools.chain(*fastq_files)]
                     bwa_wf = BWAWorkflow(os.path.join(self.params.self.output_dir, sample_name),
-                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
+                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.self.optional.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
                 else:
                     if len(fastq_files) != 1:
                         raise NotImplementedError("bwa only supports one fastq per sample: {}".format(fastq_files))
                     bwa_wf = BWAWorkflow(os.path.join(self.params.self.output_dir, sample_name),
-                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
+                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.self.optional.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
                 bwa_task = workflowRunner.addWorkflowTask('bwa_{}_{}'.format(self.identifier, sample.id), bwa_wf, dependencies=dependencies)
                 mv_task = workflowRunner.addTask('mv_{}_{}'.format(self.identifier, sample.id), "mv {} {}".format(os.path.join(self.params.self.output_dir, sample_name, "out.sorted.bam"), os.path.join(self.params.self.output_dir, sample_name, sample_name+".raw.bam")), dependencies=bwa_task, isForceLocal=True)
                 self.task[sample].append(workflowRunner.addTask('index_{}_{}'.format(self.identifier, sample.id), "{} index {}".format(self.params.samtools_path, os.path.join(self.params.self.output_dir,sample_name, sample_name+".raw.bam")), dependencies=mv_task))

--- a/zippy/modular_runner.py
+++ b/zippy/modular_runner.py
@@ -365,12 +365,12 @@ class BWARunner(ModularRunner):
                     #put R1, then R2 in a list
                     fastq_files = [x for x in itertools.chain(*fastq_files)]
                     bwa_wf = BWAWorkflow(os.path.join(self.params.self.output_dir, sample_name),
-                    self.params.bwa_path, self.params.samtools_path, self.params.genome+"/genome.fa", cores, mem, fastq_files, sample=sample.id, args=args)
+                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
                 else:
                     if len(fastq_files) != 1:
                         raise NotImplementedError("bwa only supports one fastq per sample: {}".format(fastq_files))
                     bwa_wf = BWAWorkflow(os.path.join(self.params.self.output_dir, sample_name),
-                    self.params.bwa_path, self.params.samtools_path, self.params.genome+"/genome.fa", cores, mem, fastq_files, sample=sample.id, args=args)
+                    self.params.bwa_path, self.params.samtools_path, os.path.join(self.params.genome, self.params.genome_filename), cores, mem, fastq_files, sample=sample.id, args=args)
                 bwa_task = workflowRunner.addWorkflowTask('bwa_{}_{}'.format(self.identifier, sample.id), bwa_wf, dependencies=dependencies)
                 mv_task = workflowRunner.addTask('mv_{}_{}'.format(self.identifier, sample.id), "mv {} {}".format(os.path.join(self.params.self.output_dir, sample_name, "out.sorted.bam"), os.path.join(self.params.self.output_dir, sample_name, sample_name+".raw.bam")), dependencies=bwa_task, isForceLocal=True)
                 self.task[sample].append(workflowRunner.addTask('index_{}_{}'.format(self.identifier, sample.id), "{} index {}".format(self.params.samtools_path, os.path.join(self.params.self.output_dir,sample_name, sample_name+".raw.bam")), dependencies=mv_task))


### PR DESCRIPTION
Key changes:

* BWA now consumes the genome_filename parameter in the json file instead of hardcoding to genome.fa
* samtools view after BWA now uses 0.1 * aligning threads to aid in compression. It also uses `-1` for further speedup
  * These tweaks to samtools view appear to greatly reduce "choking" of BWA (i.e. when it fills the pipe to samtools view and is simply waiting for samtools view to process before it starts aligning the next set of reads)
* samtools sort after BWA now uses *threads* not *cores*, like the bwa step before it.
* samtools sort after BWA is now memory aware
  * Memory is allocated on a per-thread basis based on both the thread count and the total memory requested. This more effectively uses system resources, and prevents the possible condition where a large number of threads is requested, but since we never change the memory allocation (defaults to ~0.75 GB per thread), sorting asks for more memory than the scheduler allocated it (capped at 32GB) potentially causing a crash
* samtools sort after BWA is no longer capped to 32GB memory
  * This allows it to take advantage of more system memory to sort larger bam files, reducing runtime by reducing disk caching for large bams.